### PR TITLE
Added support for target: es2015

### DIFF
--- a/lib/main/tsconfig/tsconfig.ts
+++ b/lib/main/tsconfig/tsconfig.ts
@@ -60,7 +60,7 @@ interface CompilerOptions {
     stripInternal?: boolean;
     suppressExcessPropertyErrors?: boolean;           // Optionally disable strict object literal assignment checking
     suppressImplicitAnyIndexErrors?: boolean;
-    target?: string;                                  // 'es3'|'es5' (default)|'es6'
+    target?: string;                                  // 'es3'|'es5' (default)|'es6'|'es2015'
     version?: boolean;
     watch?: boolean;
 }
@@ -110,7 +110,7 @@ var compilerOptionsValidation: simpleValidator.ValidationInfo = {
     stripInternal: { type: types.boolean },
     suppressExcessPropertyErrors: { type: types.boolean },
     suppressImplicitAnyIndexErrors: { type: types.boolean },
-    target: { type: types.string, validValues: ['es3', 'es5', 'es6'] },
+    target: { type: types.string, validValues: ['es3', 'es5', 'es6', 'es2015'] },
     version: { type: types.boolean },
     watch: { type: types.boolean },
 }


### PR DESCRIPTION
Added support for target: es2015 in `tsconfig.json`.  Support for this in TypeScript can be found [here](https://github.com/Microsoft/TypeScript/blob/0f67f4b6f1589756906782f1ac02e6931e1cff13/src/compiler/commandLineParser.ts#L232) and [here](https://github.com/Microsoft/TypeScript/blob/e2c95551b348b10bed7d42fdaff857143e631a0d/src/compiler/diagnosticMessages.json#L2355).  (The second example rather suggests that `es2015` is going to replace `es6` in the future.)

I didn't notice any tests associated with this - do point me in the right direction if I've missed them.